### PR TITLE
Adding legions 'Jeweled Lock pick' to picking

### DIFF
--- a/SVUI_!Core/system/_docklets/breakstuff.lua
+++ b/SVUI_!Core/system/_docklets/breakstuff.lua
@@ -73,6 +73,7 @@ ITEM PARSING
 ]]--
 do
   local SkellyKeys = {
+	[GetSpellInfo(195881)] = true, -- Jeweled Lockpick
 	[GetSpellInfo(130100)] = true, -- Ghostly Skeleton Key
 	[GetSpellInfo(94574)] = true, -- Obsidium Skeleton Key
 	[GetSpellInfo(59403)] = true, -- Titanium Skeleton Key


### PR DESCRIPTION
Adding lock pick ID to list of Skeleton keys. 
http://www.wowhead.com/spell=195881/jeweled-lockpick