### PR TITLE
Added new breakables to breakstuff.lua & typo.

### DIFF
--- a/SVUI_!Core/system/_docklets/breakstuff.lua
+++ b/SVUI_!Core/system/_docklets/breakstuff.lua
@@ -102,8 +102,10 @@ do
 		['124105']='OVERRIDE_MILLABLE', --Starlight Rose
 		['124106']='OVERRIDE_MILLABLE', --Felwort
 		['128304']='OVERRIDE_MILLABLE', --Yseralline Seed
-		['123918']='OVERRIDE_PROSPECTABLE', --leystone
+		['151565']='OVERRIDE_MILLABLE', --Astral Glory
+		['123918']='OVERRIDE_PROSPECTABLE', --Leystone
 		['123919']='OVERRIDE_PROSPECTABLE', --Felslate
+		['151564']='OVERRIDE_PROSPECTABLE', --Empyrium
 	}
 
 	local function IsThisBreakable(link)


### PR DESCRIPTION
Astral Glory for Milling
Empyrium for Prospecting
Capitalised L on Leystone note for consistency.