### PR TITLE
fixes for RaidTools and Mac options

### DIFF
--- a/SVUI_!Core/system/_docklets/raidleader.lua
+++ b/SVUI_!Core/system/_docklets/raidleader.lua
@@ -121,7 +121,11 @@ function MOD:LoadRaidLeaderTools()
 
 	local dock = self.RaidTool.Parent
 
-	self.RaidTool.Menu = CreateFrame("Frame", "SVUI_RaidToolMenu", self.RaidTool, "SecureHandlerClickTemplate");
+	self.RaidTool.Menu = CreateFrame("Frame", "SVUI_RaidToolMenu", self.RaidTool, "SecureHandlerBaseTemplate");
+	self.RaidTool.Menu:SetScript("OnMouseUp", function(panel, ...)
+		SecureHandler_OnClick(panel, "_onclick", ...);
+	end)
+
 	self.RaidTool.Menu:SetStyle("Frame", 'Transparent');
 	self.RaidTool.Menu:SetWidth(120);
 	self.RaidTool.Menu:SetHeight(140);

--- a/SVUI_Skins/components/blizzard/system.lua
+++ b/SVUI_Skins/components/blizzard/system.lua
@@ -587,7 +587,7 @@ local function SystemPanelQue()
 	InterfaceOptionsFrame:SetScript("OnDragStop", function(self)
 		self:StopMovingOrSizing()
 	end)
-	if IsMacClient() then
+	--[[if IsMacClient() then
 		MacOptionsFrame:SetStyle("!_Frame", "Default")
 		MacOptionsFrameHeader:SetTexture("")
 		MacOptionsFrameHeader:ClearAllPoints()
@@ -618,7 +618,7 @@ local function SystemPanelQue()
 		MacOptionsButtonKeybindings:SetPoint("LEFT",MacOptionsFrameOkay, -99,0)
 		MacOptionsFrameDefaults:SetWidth(96)
 		MacOptionsFrameDefaults:SetHeight(22)
-	end
+	end]]
 	OpacityFrame:RemoveTextures()
 	OpacityFrame:SetStyle("!_Frame", "Transparent", true)
 
@@ -718,9 +718,9 @@ local function SystemPanelQue()
 			SV.API:Set("ScrollBar", this)
 		end
 	end
-	
+
 	--print('test SystemPanelQue 2')
-	if(MacOptionsFrame) then
+	--[[if(MacOptionsFrame) then
 		MacOptionsFrame:RemoveTextures()
 		MacOptionsFrame:SetStyle("!_Frame")
 		MacOptionsButtonCompress:SetStyle("Button")
@@ -750,7 +750,7 @@ local function SystemPanelQue()
 		MacOptionsFrameCancel:ClearAllPoints()
 		MacOptionsFrameCancel:SetPoint("LEFT", MacOptionsFrameOkay, "RIGHT", 2, 0)
 		MacOptionsFrameCancel:SetWidth(MacOptionsFrameCancel:GetWidth() - 6)
-	end
+	end]]
 
 	--print('test SystemPanelQue 3')
 	ReportCheatingDialog:RemoveTextures()


### PR DESCRIPTION
Removing MacOptionsFrame fixes the Issue on my MBP, is this a setting deprecated by blizzard?  Fixed issues with RaidTools by adjusting RaidToolMenu to use the SecureHandlerBaseTemplate for the frame instead of the click template and then bound the OnClick events to self.RaidTool.Menu